### PR TITLE
Fix empty `event:` lines in downstream Responses streams

### DIFF
--- a/internal/agent/relay/codec/openai/responses_decode.go
+++ b/internal/agent/relay/codec/openai/responses_decode.go
@@ -486,17 +486,14 @@ func (c *ResponsesCodec) decodeStream(resp *http.Response, ch chan<- codec.Event
 			}
 		}
 
-		// Some upstreams omit the SSE `event:` line and carry the event type only in
-		// the data payload's `type` field (the OpenAI Responses spec puts `type` in
-		// the payload; the `event:` line is redundant). Fall back to raw.Type when no
-		// `event:` line was seen. When an `event:` line IS present it wins, so standard
-		// upstreams keep their exact prior behavior.
-		effectiveEvent := currentEvent
-		if effectiveEvent == "" {
-			effectiveEvent = raw.Type
+		// Responses streams may carry an event name only in the JSON payload's
+		// `type` field. Normalize the parsed SSE event name once so dispatch and
+		// any later raw passthrough use the same protocol event name.
+		if currentEvent == "" {
+			currentEvent = raw.Type
 		}
 
-		switch effectiveEvent {
+		switch currentEvent {
 		case sseconsts.ResponseCreated:
 			createdEvent := codec.Event{
 				Type: codec.EventStreamStart,

--- a/internal/agent/relay/codec/responses2responses_test.go
+++ b/internal/agent/relay/codec/responses2responses_test.go
@@ -1,6 +1,7 @@
 package codec_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/VaalaCat/ai-gateway/internal/agent/relay/codec"
@@ -51,6 +52,30 @@ func TestResponses2Responses_StreamText(t *testing.T) {
 
 	assertSSEFormat(t, sse, codec.ProtocolOpenAIResponses)
 	assertGoldenSSE(t, sse, "responses2responses/stream_text.sse")
+}
+
+func TestResponses2Responses_StreamNoEventLines(t *testing.T) {
+	outCodec := codec.GetOutbound(codec.ProtocolOpenAIResponses)
+	inCodec := codec.GetInbound(codec.ProtocolOpenAIResponses)
+
+	events, sse := roundTripStream(t,
+		"openai_responses/stream_no_event_lines.txt",
+		outCodec, inCodec, true, true)
+
+	assertEventSequence(t, events, []expectedEvent{
+		{Type: codec.EventStreamStart},
+		{Type: codec.EventContentDelta, Text: "Hello"},
+		{Type: codec.EventContentDelta, Text: " world"},
+		{Type: codec.EventUsage},
+		{Type: codec.EventDone, FinishReason: "stop"},
+	})
+	assertSSEFormat(t, sse, codec.ProtocolOpenAIResponses)
+	if strings.Contains(sse, "event: \ndata:") {
+		t.Fatalf("Responses stream contains an empty event name:\n%s", sse)
+	}
+	if !strings.Contains(sse, "event: response.created\n") {
+		t.Fatalf("Responses stream did not normalize response.created:\n%s", sse)
+	}
 }
 
 func TestResponses2Responses_StreamToolCall(t *testing.T) {


### PR DESCRIPTION
Fix an issue where the gateway outputs an empty `event:` line to downstream clients when the upstream Responses SSE stream does not include an `event:` line.

## Problem

When the upstream sends:

```text
data: {"type":"response.created","response":{"status":"in_progress", ...}}
```

Because the `event:` line is missing, `currentEvent` is empty when events are constructed in `internal/agent/relay/codec/openai/responses_decode.go`. This causes the gateway to emit:

```text
event:
data: {"type":"response.created","response":{"status":"in_progress", ...}}
```

This can cause issues for some agents.

## Fix

- Use `raw.Type` to populate missing event names.
- Add a Responses → Responses regression test for streams without `event:` lines.